### PR TITLE
Fix JitPack build by declaring maven-publish config explicitly

### DIFF
--- a/PrefsHelper/build.gradle.kts
+++ b/PrefsHelper/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
 	alias(libs.plugins.android.library)
 	alias(libs.plugins.dokka)
+	`maven-publish`
 }
 
 group = "com.github.projectdelta6"
@@ -32,6 +33,23 @@ android {
 	kotlin {
 		compilerOptions {
 			jvmTarget.set(JvmTarget.JVM_11)
+		}
+	}
+
+	publishing {
+		singleVariant("release") {
+			withSourcesJar()
+			withJavadocJar()
+		}
+	}
+}
+
+afterEvaluate {
+	publishing {
+		publications {
+			register<MavenPublication>("release") {
+				from(components["release"])
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- JitPack 1.7.0 build failed with `Too many characters in a character literal` on \`'release'\`.
- AGP 9.0+ no longer auto-registers \`publishToMavenLocal\` for Android library modules, so JitPack's fallback heuristic tried to inject \`android { publishing { singleVariant('release') } }\` using Groovy single-quoted syntax — which Kotlin parses as a malformed \`Char\` literal.
- Apply the \`maven-publish\` plugin, declare \`android.publishing.singleVariant("release")\` (with \`withSourcesJar()\` / \`withJavadocJar()\`), and register the release publication in an \`afterEvaluate\` block so JitPack stops injecting.

## Test plan
- [x] \`./gradlew :PrefsHelper:publishToMavenLocal -Pgroup=com.github.projectdelta6 -Pversion=1.7.1\` — BUILD SUCCESSFUL
- [x] Local \`~/.m2/repository/com/github/projectdelta6/PrefsHelper/1.7.1/\` contains the expected \`.aar\`, \`.pom\`, \`.module\`, \`-sources.jar\`, \`-javadoc.jar\`
- [x] Reviewer: after merge, re-tag 1.7.0 at the fix commit and let JitPack rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)